### PR TITLE
respect rule of 0

### DIFF
--- a/include/bezier.h
+++ b/include/bezier.h
@@ -159,11 +159,6 @@ namespace Bezier
                 this->normalize();
         }
 
-        Vec2(const Vec2& other)
-            : x(other.x)
-            , y(other.y)
-        {}
-
         Vec2(const Vec2& other, bool normalize)
             : Vec2(other.x, other.y, normalize)
         {}


### PR DESCRIPTION
fix #9

It was easier than I though.
I think this copy constructor is useless and doesn't respect rule of 0. Please confirm.