### PR TITLE
remove const from return type

### DIFF
--- a/include/bezier.h
+++ b/include/bezier.h
@@ -82,7 +82,7 @@ namespace Bezier
             return N + 1;
         }
 
-        const size_t operator [](size_t idx) const
+        size_t operator [](size_t idx) const
         {
             assert(idx < size());
             return mCoefficients[idx];


### PR DESCRIPTION
```
bezier.h:85:9: warning: type qualifiers ignored on function return type [-Wignored-qualifiers]
   85 |         const size_t operator [](size_t idx) const
      |         ^~~~~
```